### PR TITLE
stop dnsmasq from listening on minikube's interface

### DIFF
--- a/minikube-ingress-dns-macos
+++ b/minikube-ingress-dns-macos
@@ -15,7 +15,8 @@ if [[ "$1" == "start" ]]; then
   ip="$(minikube ip)"
   echo "The IP address of running a cluster: ${ip}"
 
-  config="address=/${MINIKUBE_INGRESS_DNS_DOMAIN}/${ip}"
+  config="address=/${MINIKUBE_INGRESS_DNS_DOMAIN}/${ip}
+except-interface=${ip}""
   config_file="/usr/local/etc/dnsmasq.conf"
 
   if [[ "$config" != "$(cat $config_file 2>/dev/null)" ]]; then
@@ -23,7 +24,7 @@ if [[ "$1" == "start" ]]; then
     echo "$config" > "$config_file"
 
     echo "Restarting dnsmasq..."
-    sudo brew services start dnsmasq
+    sudo brew services restart dnsmasq
   fi
 
   if [[ ! -f "/etc/resolver/${MINIKUBE_INGRESS_DNS_DOMAIN}" ]]; then


### PR DESCRIPTION
- restart dnsmasq instead of start in case it's already running
- dnsmasq will override the resolv.conf of minikube with your machine settings, causing dns to not resolve. Exempting the interface resolves this.