### PR TITLE
fix dnsmasq+minikube bug on osx when running on port 53

### DIFF
--- a/Formula/minikube-ingress-dns.rb
+++ b/Formula/minikube-ingress-dns.rb
@@ -1,7 +1,7 @@
 class MinikubeIngressDns < Formula
   desc "Configure and restart dnsmasq automatically for Kubernetes Ingress LB on minikube"
   homepage "https://github.com/superbrothers/minikube-ingress-dns"
-  version "v1.0.0"
+  version "v1.0.1"
   url "https://github.com/superbrothers/minikube-ingress-dns.git", tag: version
   head "https://github.com/superbrothers/minikube-ingress-dns.git", branch: "master"
 

--- a/Formula/minikube-ingress-dns.rb
+++ b/Formula/minikube-ingress-dns.rb
@@ -2,8 +2,8 @@ class MinikubeIngressDns < Formula
   desc "Configure and restart dnsmasq automatically for Kubernetes Ingress LB on minikube"
   homepage "https://github.com/superbrothers/minikube-ingress-dns"
   version "v1.0.1"
-  url "https://github.com/superbrothers/minikube-ingress-dns.git", tag: version
-  head "https://github.com/superbrothers/minikube-ingress-dns.git", branch: "master"
+  url "https://github.com/orefalo/minikube-ingress-dns.git", tag: version
+  head "https://github.com/orefalo/minikube-ingress-dns.git", branch: "master"
 
   def install
     (prefix/"etc/minikube-ingress-dns").install %w(

--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 This repository contains the script files in order to configure and restart dnsmasq automatically for Kubernetes Ingress LB on minikube after running `minikube start`. For more details, see [this article](http://qiita.com/superbrothers/items/13d8ce012ef23e22cb74) (In Japanese).
 
+This version is a fork from the original. On OSX catalina, minikube+dnsmasq and not playing well together when dealing with port 53. This version alters the port to 5354 and runs dnsmasq as a non root process.
+
 ## Installation
 
 You can install minikube-ingress-dns with homebrew as follows:
 
 ```
-$ brew tap superbrothers/minikube-ingress-dns git://github.com/superbrothers/minikube-ingress-dns.git
+$ brew tap orefalo/minikube-ingress-dns git://github.com/orefalo/minikube-ingress-dns.git
 $ brew install minikube-ingress-dns
 ```
 
 Otherwise you just clone this repository to install:
 
 ```
-$ git clone https://github.com/superbrothers/minikube-ingress-dns.git /path/to/minikube-ingress-dns
+$ git clone https://github.com/orefalo/minikube-ingress-dns.git /path/to/minikube-ingress-dns
 ```
 
 ## Requirement

--- a/common.sh
+++ b/common.sh
@@ -31,6 +31,7 @@ minikube_ingress_dns() {
   local dnsmasq_config="$(cat <<EOL
 bind-interfaces
 listen-address=127.0.0.1
+port=5354
 address=/${MINIKUBE_INGRESS_DNS_DOMAIN}/${ip}
 EOL
 )"
@@ -43,7 +44,7 @@ EOL
     exe restart_dnsmasq
   fi
 
-  exe dig +noall +answer "${MINIKUBE_INGRESS_DNS_DOMAIN}" @127.0.0.1
+  exe dig +noall +answer "${MINIKUBE_INGRESS_DNS_DOMAIN}" @127.0.0.1 -p 5354
 }
 
 exe() {

--- a/minikube-ingress-dns-macos
+++ b/minikube-ingress-dns-macos
@@ -13,6 +13,18 @@ command minikube $@
 
 [[ -n "$DEBUG" ]] && set -x
 
+if [[ "$1" == "stop" ]]; then
+	brew services stop dnsmasq
+	exit
+fi
+
+if [[ "$1" == "delete" ]]; then
+	brew services stop dnsmasq
+	$(dirname $0)/clean_macos
+	exit
+fi
+
+
 [[ "$1" != "start" ]] && exit
 
 source $(dirname $0)/common.sh
@@ -25,11 +37,9 @@ write_to_dnsmasq_config_file() {
 
 # The way of restarting dnsmasq in this environment
 restart_dnsmasq() {
-  sudo brew services restart dnsmasq
+  brew services restart dnsmasq
 }
 
-# Setup dnsmasq for ingress lb in minikube
-minikube_ingress_dns
 
 # To configure additional resolvers for minikube ingress dns domain
 if [[ ! -f "/etc/resolver/${MINIKUBE_INGRESS_DNS_DOMAIN}" ]]; then
@@ -38,6 +48,11 @@ if [[ ! -f "/etc/resolver/${MINIKUBE_INGRESS_DNS_DOMAIN}" ]]; then
 
   tmpfile=$(mktemp)
   echo "nameserver 127.0.0.1" > $tmpfile
+  echo "port 5354" >> $tmpfile
   exe sudo mv $tmpfile /etc/resolver/${MINIKUBE_INGRESS_DNS_DOMAIN}
 fi
+
+# Setup dnsmasq for ingress lb in minikube
+minikube_ingress_dns
+
 # vim: ft=sh ts=2 sts=2 sw=2


### PR DESCRIPTION
fix dnsmasq+minikube bug on osx when running on port 53

as per https://github.com/superbrothers/minikube-ingress-dns/issues/5